### PR TITLE
Creating some round trip tests to verify the extractor wrapping for Option.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,10 @@ libraryDependencies ++= Seq(
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.1.3",
     "com.timgroup" % "java-statsd-client" % "2.0.0",
     "org.scalatest" %% "scalatest" % "2.0.M5b" % "test",
-    "org.mockito" % "mockito-core" % "1.9.5" % "test"
+    "org.mockito" % "mockito-core" % "1.9.5" % "test",
+    "com.sun.jersey.jersey-test-framework" % "jersey-test-framework-core" % "1.17.1" % "test",
+    "com.sun.jersey.jersey-test-framework" % "jersey-test-framework-inmemory" % "1.17.1" % "test",
+    "com.sun.jersey" % "jersey-client" % "1.17.1" % "test"
 )
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")

--- a/src/test/scala/com/yammer/dropwizard/scala/jersey/tests/OptionTest.scala
+++ b/src/test/scala/com/yammer/dropwizard/scala/jersey/tests/OptionTest.scala
@@ -1,0 +1,91 @@
+package com.yammer.dropwizard.scala.jersey.tests
+
+import com.sun.jersey.test.framework.{LowLevelAppDescriptor, AppDescriptor, JerseyTest}
+import javax.ws.rs.{Path, Produces, GET, QueryParam}
+import javax.ws.rs.core.MediaType
+import com.yammer.dropwizard.jersey.DropwizardResourceConfig
+import junit.framework.Assert
+import org.junit.Test
+import com.yammer.dropwizard.scala.inject.ScalaCollectionsQueryParamInjectableProvider
+
+class OptionTest extends JerseyTest {
+  @Path("/")
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  class ExampleResource {
+    @Path("/opt/")
+    @GET
+    def none(@QueryParam("id") id: Option[String]): Boolean = {
+      id == None
+    }
+
+    @Path("/string/")
+    @GET
+    def string(@QueryParam("id") id: Option[String]): String = {
+      Assert.assertTrue(id.get.isInstanceOf[String])
+      id.get
+    }
+
+    @Path("/int/")
+    @GET
+    def int(@QueryParam("id") id: Option[java.lang.Integer]): Int = {
+      Assert.assertTrue(id.get.isInstanceOf[java.lang.Integer])
+      id.get
+    }
+
+    @Path("/long/")
+    @GET
+    def long(@QueryParam("id") id: Option[java.lang.Long]): Long = {
+      Assert.assertTrue(id.get.isInstanceOf[java.lang.Long])
+      id.get
+    }
+
+    @Path("/boolean/")
+    @GET
+    def boolean(@QueryParam("id") id: Option[java.lang.Boolean]): Boolean = {
+      Assert.assertTrue(id.get.isInstanceOf[java.lang.Boolean])
+      id.get
+    }
+  }
+
+  override def configure(): AppDescriptor = {
+    val config = new DropwizardResourceConfig(true)
+    config.getClasses.add(classOf[ScalaCollectionsQueryParamInjectableProvider])
+    config.getSingletons.add(new ExampleResource())
+    new LowLevelAppDescriptor.Builder(config).build()
+  }
+
+  @Test
+  def injectsNoneInsteadOfNull() {
+    Assert.assertTrue(client().resource("/opt/").get(classOf[Boolean]))
+  }
+
+  @Test
+  def injectsEmptyString() {
+    Assert.assertEquals("", client().resource("/string/").queryParam("id", "").get(classOf[String]))
+  }
+
+  @Test
+  def injectsString() {
+    Assert.assertEquals("id", client().resource("/string/").queryParam("id", "id").get(classOf[String]))
+  }
+
+  @Test
+  def injectsInt() {
+    Assert.assertEquals(200, client().resource("/int/").queryParam("id", "200").get(classOf[Int]))
+  }
+
+  @Test
+  def injectsLong() {
+    Assert.assertEquals(200L, client().resource("/long/").queryParam("id", "200").get(classOf[Long]))
+  }
+
+  @Test
+  def injectsBooleanTrue() {
+    Assert.assertTrue(client().resource("/boolean/").queryParam("id", "true").get(classOf[Boolean]))
+  }
+
+  @Test
+  def injectsBooleanFalse() {
+    Assert.assertFalse(client().resource("/boolean/").queryParam("id", "false").get(classOf[Boolean]))
+  }
+}


### PR DESCRIPTION
Adding the extractor code is doing some good. These tests demonstrate it works for java primitive types, but not scala primitive types.

I'm trying to figure it out but Option[java.lang.Long] works whereas Option[Long] does not.
